### PR TITLE
refactor(nav-icon): 네비게이션 아이콘 크기 클래스 중복 제거

### DIFF
--- a/src/pages/(study)/components/layout/sidebar/SidebarNav.tsx
+++ b/src/pages/(study)/components/layout/sidebar/SidebarNav.tsx
@@ -34,7 +34,7 @@ function SidebarNav() {
                             : 'text-muted-foreground group-hover:text-primary/80'
                         }`}
                       >
-                        {item.icon}
+                        <item.icon className='w-5 h-5' />
                       </span>
                       <span
                         className={`truncate font-semibold transition-colors duration-200 ease-out ${

--- a/src/pages/(study)/constants/nav.tsx
+++ b/src/pages/(study)/constants/nav.tsx
@@ -13,36 +13,36 @@ export const STUDY_NAV_ITEMS = [
   {
     to: ROUTES.STUDY.DASHBOARD,
     label: '대시보드',
-    icon: <LayoutDashboard className='w-5 h-5' />,
+    icon: LayoutDashboard,
   },
   {
     to: ROUTES.STUDY.DOCUMENT,
     label: '문서',
-    icon: <FileText className='w-5 h-5' />,
+    icon: FileText,
   },
   {
     to: ROUTES.STUDY.PROGRESS,
     label: '진척도',
-    icon: <TrendingUp className='w-5 h-5' />,
+    icon: TrendingUp,
   },
   {
     to: ROUTES.STUDY.SCHEDULE,
     label: '일정',
-    icon: <Calendar className='w-5 h-5' />,
+    icon: Calendar,
   },
   {
     to: ROUTES.STUDY.QUIZ,
     label: '퀴즈',
-    icon: <HelpCircle className='w-5 h-5' />,
+    icon: HelpCircle,
   },
   {
     to: ROUTES.STUDY.RETRO,
     label: '회고',
-    icon: <ClipboardList className='w-5 h-5' />,
+    icon: ClipboardList,
   },
   {
     to: ROUTES.STUDY.ADMIN,
     label: '관리자 기능',
-    icon: <Settings className='w-5 h-5' />,
+    icon: Settings,
   },
 ] as const;


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

네비게이션 아이콘의 반복되는 크기 클래스를 SidebarNav 컴포넌트에서 공통 처리하도록 리팩토링하여 코드 중복을 제거하고 유지보수성을 향상시켰습니다.

## 🔗 작업 내용

- `nav.tsx`에서 아이콘 컴포넌트의 하드코딩된 `className` 제거
- `SidebarNav.tsx`에서 아이콘 렌더링 시 공통 크기 클래스 적용

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

- 데이터와 UI 로직을 분리하여 `nav.tsx`는 순수 데이터 정의에 집중하도록 개선하였습니다.
- `SidebarNav`에서 아이콘 크기를 일괄 관리하도록 하여 불필요한 코드 중복을 제거하고, 나중에 다른 컴포넌트에서 `STUDY_NAV_ITEMS`를 사용할 때도 각각 다른 크기 적용이 가능하도록 하여 유연성을 확보하였습니다.

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

아이콘 크기를 변경하려면 `SidebarNav.tsx`의 `className="w-5 h-5"` 부분만 수정하면 됩니다.

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
