### PR TITLE
feat(reflection): 스터디 회고 페이지 UI 구현

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -17,7 +17,7 @@ export const ROUTES = {
     PROGRESS: 'progress',
     SCHEDULE: 'schedule',
     QUIZ: 'quiz',
-    RETRO: 'retro',
+    REFLECTION: 'reflection',
     ADMIN: {
       ROOT: 'admin',
       MEMBERS: 'admin/members',

--- a/src/pages/(study)/constants/nav.tsx
+++ b/src/pages/(study)/constants/nav.tsx
@@ -36,7 +36,7 @@ export const STUDY_NAV_ITEMS = [
     icon: HelpCircle,
   },
   {
-    to: ROUTES.STUDY.RETRO,
+    to: ROUTES.STUDY.REFLECTION,
     label: '회고',
     icon: ClipboardList,
   },

--- a/src/pages/(study)/dashboard/DashboardPage.tsx
+++ b/src/pages/(study)/dashboard/DashboardPage.tsx
@@ -69,7 +69,7 @@ const DashboardPage = () => {
         {/* 회고, 퀴즈 - 한줄에 */}
         <DashboardRow cols={2}>
           <RetrospectSection
-            onClick={() => navigateToStudy(ROUTES.STUDY.RETRO)}
+            onClick={() => navigateToStudy(ROUTES.STUDY.REFLECTION)}
           />
           <QuizSection onClick={() => navigateToStudy(ROUTES.STUDY.QUIZ)} />
         </DashboardRow>

--- a/src/pages/(study)/index.ts
+++ b/src/pages/(study)/index.ts
@@ -8,6 +8,7 @@ export * from './components';
 export * from './dashboard';
 export * from './document';
 export * from './progress';
+export * from './reflection';
 export * from './admin';
 export {
   MemberManagement,

--- a/src/pages/(study)/reflection/ReflectionDetailPage.tsx
+++ b/src/pages/(study)/reflection/ReflectionDetailPage.tsx
@@ -1,0 +1,206 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { REFLECTION_TEXTS, SCORE_LABELS, SCORE_RANGE } from './constants';
+import { mockSchedules, mockReflectionDetails } from './mock';
+import { ScoreSlider, ScheduleDropdown } from './components';
+import type { ReflectionFormData, Schedule } from './types';
+
+/**
+ * 회고 작성/수정 페이지
+ */
+const ReflectionDetailPage = () => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEdit = Boolean(id) && !window.location.pathname.endsWith('/write');
+
+  // 폼 상태
+  const [formData, setFormData] = useState<ReflectionFormData>({
+    schedule_id: null,
+    title: '',
+    satisfaction_score: 5,
+    understanding_score: 5,
+    participation_score: 5,
+    learned_content: '',
+    improvement: '',
+  });
+
+  // 스케줄 목록
+  const [schedules] = useState<Schedule[]>(mockSchedules);
+
+  // 수정 모드일 때 기존 데이터 로드
+  useEffect(() => {
+    if (isEdit && id) {
+      // 실제로는 API 호출로 데이터를 가져와야 함
+      const existingData = mockReflectionDetails.find(
+        (r) => r.id === parseInt(id),
+      );
+      if (existingData) {
+        setFormData({
+          schedule_id: existingData.schedule_id,
+          title: existingData.title,
+          satisfaction_score: existingData.satisfaction_score,
+          understanding_score: existingData.understanding_score,
+          participation_score: existingData.participation_score,
+          learned_content: existingData.learned_content,
+          improvement: existingData.improvement,
+        });
+      }
+    }
+  }, [isEdit, id]);
+
+  // 입력 핸들러
+  const handleInputChange = (
+    field: keyof ReflectionFormData,
+    value: string | number | null,
+  ) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  // 저장 핸들러
+  const handleSave = () => {
+    // 실제로는 API 호출
+    console.log('저장할 데이터:', formData);
+    // 성공 시 목록으로 이동
+    navigate('/study/reflection');
+  };
+
+  // 취소 핸들러
+  const handleCancel = () => {
+    navigate('/study/reflection');
+  };
+
+  return (
+    <div className='h-full flex flex-col bg-background'>
+      {/* 헤더 */}
+      <div className='px-6 py-6 border-b border-border bg-background'>
+        <h1 className='text-2xl font-bold text-primary'>
+          {isEdit ? '회고 수정' : REFLECTION_TEXTS.DETAIL_TITLE}
+        </h1>
+      </div>
+
+      {/* 메인 컨텐츠 */}
+      <div className='flex-1 overflow-y-auto bg-background p-6'>
+        <div className='max-w-4xl mx-auto space-y-6'>
+          {/* 제목 입력 */}
+          <div className='bg-card rounded-lg border border-border p-6'>
+            <label
+              htmlFor='title'
+              className='block text-lg font-semibold text-foreground mb-4'
+            >
+              제목
+            </label>
+            <input
+              id='title'
+              type='text'
+              value={formData.title}
+              onChange={(e) => handleInputChange('title', e.target.value)}
+              placeholder='회고 제목을 입력해주세요'
+              className='w-full px-4 py-3 bg-background border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent'
+            />
+          </div>
+
+          {/* 스케줄 선택 */}
+          <div className='bg-card rounded-lg border border-border p-6'>
+            <h3 className='text-lg font-semibold text-foreground mb-4'>
+              연관된 스터디 일정
+            </h3>
+            <ScheduleDropdown
+              schedules={schedules}
+              selectedScheduleId={formData.schedule_id}
+              onScheduleChange={(scheduleId) =>
+                handleInputChange('schedule_id', scheduleId)
+              }
+              placeholder={REFLECTION_TEXTS.SELECT_SCHEDULE_PLACEHOLDER}
+            />
+          </div>
+
+          {/* 점수 평가 */}
+          <div className='space-y-4'>
+            <h3 className='text-lg font-semibold text-foreground'>평가</h3>
+
+            <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+              <ScoreSlider
+                label={SCORE_LABELS.SATISFACTION}
+                value={formData.satisfaction_score}
+                onChange={(value) =>
+                  handleInputChange('satisfaction_score', value)
+                }
+                min={SCORE_RANGE.MIN}
+                max={SCORE_RANGE.MAX}
+              />
+
+              <ScoreSlider
+                label={SCORE_LABELS.UNDERSTANDING}
+                value={formData.understanding_score}
+                onChange={(value) =>
+                  handleInputChange('understanding_score', value)
+                }
+                min={SCORE_RANGE.MIN}
+                max={SCORE_RANGE.MAX}
+              />
+
+              <ScoreSlider
+                label={SCORE_LABELS.PARTICIPATION}
+                value={formData.participation_score}
+                onChange={(value) =>
+                  handleInputChange('participation_score', value)
+                }
+                min={SCORE_RANGE.MIN}
+                max={SCORE_RANGE.MAX}
+              />
+            </div>
+          </div>
+
+          {/* 학습 내용 */}
+          <div className='bg-card rounded-lg border border-border p-6'>
+            <h3 className='text-lg font-semibold text-foreground mb-4'>
+              {REFLECTION_TEXTS.LEARNED_CONTENT_QUESTION}
+            </h3>
+            <textarea
+              value={formData.learned_content}
+              onChange={(e) =>
+                handleInputChange('learned_content', e.target.value)
+              }
+              placeholder='이번 스터디에서 배운 내용과 느낀 점을 자유롭게 작성해주세요'
+              className='w-full h-32 px-4 py-3 bg-background border border-border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent'
+            />
+          </div>
+
+          {/* 개선점 */}
+          <div className='bg-card rounded-lg border border-border p-6'>
+            <h3 className='text-lg font-semibold text-foreground mb-4'>
+              {REFLECTION_TEXTS.IMPROVEMENT_QUESTION}
+            </h3>
+            <textarea
+              value={formData.improvement}
+              onChange={(e) => handleInputChange('improvement', e.target.value)}
+              placeholder='다음 스터디에서 개선하고 싶은 점이나 제안사항을 작성해주세요'
+              className='w-full h-32 px-4 py-3 bg-background border border-border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent'
+            />
+          </div>
+
+          {/* 하단 버튼들 */}
+          <div className='flex justify-end gap-3 pt-6'>
+            <button
+              onClick={handleCancel}
+              className='px-6 py-3 bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary-hover transition-colors font-semibold'
+            >
+              취소
+            </button>
+            <button
+              onClick={handleSave}
+              className='px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary-hover transition-colors font-semibold'
+            >
+              {isEdit ? '수정 완료' : '작성 완료'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReflectionDetailPage;

--- a/src/pages/(study)/reflection/ReflectionPage.tsx
+++ b/src/pages/(study)/reflection/ReflectionPage.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Plus, Filter } from 'lucide-react';
+import { REFLECTION_TEXTS } from './constants';
+import { mockReflections } from './mock';
+import type { ReflectionListItem } from './types';
+
+/**
+ * 회고 목록 페이지
+ */
+const ReflectionPage = () => {
+  const navigate = useNavigate();
+  const [showMyReflectionsOnly, setShowMyReflectionsOnly] = useState(false);
+  const [reflections] = useState<ReflectionListItem[]>(mockReflections);
+
+  const handleWriteReflection = () => {
+    navigate('write');
+  };
+
+  const handleReflectionClick = (reflectionId: number) => {
+    navigate(`${reflectionId}`);
+  };
+
+  const filteredReflections = showMyReflectionsOnly
+    ? reflections.filter((reflection) => reflection.author === '김경대') // 실제로는 현재 사용자와 비교
+    : reflections;
+
+  return (
+    <div className='h-full flex flex-col bg-background'>
+      {/* 헤더 */}
+      <div className='flex items-center justify-between px-6 py-6 border-b border-border bg-background'>
+        <div>
+          <h1 className='text-2xl font-bold text-primary'>
+            {REFLECTION_TEXTS.PAGE_TITLE}
+          </h1>
+        </div>
+
+        <div className='flex items-center gap-3'>
+          <button
+            onClick={() => setShowMyReflectionsOnly(!showMyReflectionsOnly)}
+            className={`flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm transition-colors font-semibold ${
+              showMyReflectionsOnly
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-secondary text-secondary-foreground hover:bg-secondary-hover'
+            }`}
+          >
+            <Filter className='w-4 h-4' />
+            <span>{REFLECTION_TEXTS.MY_REFLECTIONS_ONLY}</span>
+          </button>
+
+          <button
+            onClick={handleWriteReflection}
+            className='flex items-center gap-2 px-4 py-2.5 bg-primary text-primary-foreground rounded-lg text-sm hover:bg-primary-hover transition-colors font-semibold'
+          >
+            <Plus className='w-4 h-4' />
+            <span>{REFLECTION_TEXTS.WRITE_BUTTON}</span>
+          </button>
+        </div>
+      </div>
+
+      {/* 메인 컨텐츠 영역 */}
+      <div className='flex-1 overflow-y-auto bg-background p-6'>
+        <div className='space-y-4'>
+          {filteredReflections.length === 0 ? (
+            <div className='text-center py-12 text-muted-foreground'>
+              작성된 회고가 없습니다.
+            </div>
+          ) : (
+            filteredReflections.map((reflection) => (
+              <div
+                key={reflection.id}
+                onClick={() => handleReflectionClick(reflection.id)}
+                className='bg-card rounded-lg border border-border p-6 cursor-pointer hover:shadow-md transition-shadow'
+              >
+                <div className='flex items-start justify-between'>
+                  <div className='flex-1'>
+                    <h3 className='text-lg font-semibold text-foreground mb-2'>
+                      {reflection.title}
+                    </h3>
+
+                    <div className='flex items-center gap-4 text-sm text-muted-foreground'>
+                      <div className='flex items-center gap-1'>
+                        <span>작성자: {reflection.author}</span>
+                      </div>
+
+                      {reflection.schedule_title && (
+                        <div className='flex items-center gap-1'>
+                          <span>
+                            연관된 스터디: {reflection.schedule_title}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className='text-sm text-muted-foreground'>
+                    {new Date(reflection.updated_at).toLocaleDateString(
+                      'ko-KR',
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* 플로팅 액션 버튼 */}
+      <button
+        onClick={handleWriteReflection}
+        className='fixed bottom-6 right-6 w-14 h-14 bg-primary text-primary-foreground rounded-full shadow-lg hover:bg-primary-hover transition-colors flex items-center justify-center'
+      >
+        <Plus className='w-6 h-6' />
+      </button>
+    </div>
+  );
+};
+
+export default ReflectionPage;

--- a/src/pages/(study)/reflection/ReflectionPage.tsx
+++ b/src/pages/(study)/reflection/ReflectionPage.tsx
@@ -14,11 +14,11 @@ const ReflectionPage = () => {
   const [reflections] = useState<ReflectionListItem[]>(mockReflections);
 
   const handleWriteReflection = () => {
-    navigate('write');
+    navigate('/study/reflection/write');
   };
 
   const handleReflectionClick = (reflectionId: number) => {
-    navigate(`${reflectionId}`);
+    navigate(`/study/reflection/${reflectionId}`);
   };
 
   const filteredReflections = showMyReflectionsOnly

--- a/src/pages/(study)/reflection/ReflectionViewPage.tsx
+++ b/src/pages/(study)/reflection/ReflectionViewPage.tsx
@@ -1,0 +1,211 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, Edit, Calendar, User } from 'lucide-react';
+import { mockReflectionDetails, mockSchedules } from './mock';
+import type { Reflection, Schedule } from './types';
+
+/**
+ * 회고 읽기 전용 상세보기 페이지
+ */
+const ReflectionViewPage = () => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const [reflection, setReflection] = useState<Reflection | null>(null);
+  const [schedules] = useState<Schedule[]>(mockSchedules);
+
+  // 현재 사용자 (실제로는 인증 상태에서 가져와야 함)
+  const currentUserId = 5; // 김경대 (첫 번째 회고 작성자)
+
+  useEffect(() => {
+    if (id) {
+      // 실제로는 API 호출로 데이터를 가져와야 함
+      const reflectionData = mockReflectionDetails.find(
+        (r) => r.id === parseInt(id),
+      );
+      setReflection(reflectionData || null);
+    }
+  }, [id]);
+
+  if (!reflection) {
+    return <div>로딩 중...</div>;
+  }
+
+  const isAuthor = reflection.study_member_id === currentUserId;
+  const selectedSchedule = schedules.find(
+    (s) => s.schedule_id === reflection.schedule_id,
+  );
+
+  // 작성자 이름 매핑
+  const getAuthorName = (studyMemberId: number) => {
+    const authorMap: { [key: number]: string } = {
+      5: '김경대',
+      6: '이영희',
+      7: '박민수',
+    };
+    return authorMap[studyMemberId] || '알 수 없음';
+  };
+
+  const handleEdit = () => {
+    navigate(`/study/reflection/${id}/edit`);
+  };
+
+  const handleBack = () => {
+    navigate('/study/reflection');
+  };
+
+  return (
+    <div className='h-full flex flex-col bg-background'>
+      {/* 헤더 */}
+      <div className='px-6 py-6 border-b border-border bg-background'>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-3'>
+            <button
+              onClick={handleBack}
+              className='p-2 hover:bg-accent rounded-lg transition-colors'
+            >
+              <ArrowLeft className='w-5 h-5 text-foreground' />
+            </button>
+            <h1 className='text-2xl font-bold text-primary'>회고 상세</h1>
+          </div>
+
+          {isAuthor && (
+            <button
+              onClick={handleEdit}
+              className='flex items-center gap-2 px-4 py-2.5 bg-primary text-primary-foreground rounded-lg text-sm hover:bg-primary-hover transition-colors font-semibold'
+            >
+              <Edit className='w-4 h-4' />
+              <span>수정</span>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* 메인 컨텐츠 */}
+      <div className='flex-1 overflow-y-auto bg-background p-6'>
+        <div className='max-w-4xl mx-auto space-y-6'>
+          {/* 제목 */}
+          <div className='bg-card rounded-lg border border-border p-6'>
+            <h2 className='text-xl font-bold text-foreground mb-2'>
+              {reflection.title}
+            </h2>
+
+            <div className='flex items-center gap-4 text-sm text-muted-foreground'>
+              <div className='flex items-center gap-1'>
+                <User className='w-4 h-4' />
+                <span>작성자: {getAuthorName(reflection.study_member_id)}</span>
+              </div>
+              <div className='flex items-center gap-1'>
+                <Calendar className='w-4 h-4' />
+                <span>
+                  {new Date(reflection.updated_at).toLocaleDateString('ko-KR')}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* 연관된 스터디 일정 */}
+          {selectedSchedule && (
+            <div className='bg-card rounded-lg border border-border p-6'>
+              <h3 className='text-lg font-semibold text-foreground mb-2'>
+                연관된 스터디 일정
+              </h3>
+              <p className='text-foreground'>
+                {selectedSchedule.schedule_title}
+              </p>
+            </div>
+          )}
+
+          {/* 점수 평가 */}
+          <div className='space-y-4'>
+            <h3 className='text-lg font-semibold text-foreground'>평가</h3>
+
+            <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+              <div className='bg-card rounded-lg border border-border p-6'>
+                <div className='flex items-center justify-between mb-4'>
+                  <h4 className='text-lg font-semibold text-foreground'>
+                    전체 만족도
+                  </h4>
+                  <span className='text-2xl font-bold text-primary'>
+                    {reflection.satisfaction_score}/10
+                  </span>
+                </div>
+                <div className='w-full bg-secondary rounded-full h-2'>
+                  <div
+                    className='bg-primary h-2 rounded-full transition-all'
+                    style={{
+                      width: `${(reflection.satisfaction_score / 10) * 100}%`,
+                    }}
+                  />
+                </div>
+              </div>
+
+              <div className='bg-card rounded-lg border border-border p-6'>
+                <div className='flex items-center justify-between mb-4'>
+                  <h4 className='text-lg font-semibold text-foreground'>
+                    내용 이해도
+                  </h4>
+                  <span className='text-2xl font-bold text-primary'>
+                    {reflection.understanding_score}/10
+                  </span>
+                </div>
+                <div className='w-full bg-secondary rounded-full h-2'>
+                  <div
+                    className='bg-primary h-2 rounded-full transition-all'
+                    style={{
+                      width: `${(reflection.understanding_score / 10) * 100}%`,
+                    }}
+                  />
+                </div>
+              </div>
+
+              <div className='bg-card rounded-lg border border-border p-6'>
+                <div className='flex items-center justify-between mb-4'>
+                  <h4 className='text-lg font-semibold text-foreground'>
+                    참여도
+                  </h4>
+                  <span className='text-2xl font-bold text-primary'>
+                    {reflection.participation_score}/10
+                  </span>
+                </div>
+                <div className='w-full bg-secondary rounded-full h-2'>
+                  <div
+                    className='bg-primary h-2 rounded-full transition-all'
+                    style={{
+                      width: `${(reflection.participation_score / 10) * 100}%`,
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 학습 내용 */}
+          <div className='bg-card rounded-lg border border-border p-6'>
+            <h3 className='text-lg font-semibold text-foreground mb-4'>
+              이번 스터디에서 공부한 점과 느낀점은 무엇인가요?
+            </h3>
+            <div className='bg-background border border-border rounded-lg p-4 min-h-[120px]'>
+              <p className='text-foreground whitespace-pre-wrap'>
+                {reflection.learned_content}
+              </p>
+            </div>
+          </div>
+
+          {/* 개선점 */}
+          <div className='bg-card rounded-lg border border-border p-6'>
+            <h3 className='text-lg font-semibold text-foreground mb-4'>
+              다음 스터디에서 개선할 점은 무엇인가요?
+            </h3>
+            <div className='bg-background border border-border rounded-lg p-4 min-h-[120px]'>
+              <p className='text-foreground whitespace-pre-wrap'>
+                {reflection.improvement}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReflectionViewPage;

--- a/src/pages/(study)/reflection/components/ScheduleDropdown.tsx
+++ b/src/pages/(study)/reflection/components/ScheduleDropdown.tsx
@@ -1,0 +1,90 @@
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+import type { Schedule } from '../types';
+
+interface ScheduleDropdownProps {
+  schedules: Schedule[];
+  selectedScheduleId: number | null;
+  onScheduleChange: (scheduleId: number | null) => void;
+  placeholder?: string;
+}
+
+const ScheduleDropdown = ({
+  schedules,
+  selectedScheduleId,
+  onScheduleChange,
+  placeholder = '연관된 스터디 일정을 선택해주세요..',
+}: ScheduleDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectedSchedule = schedules.find(
+    (s) => s.schedule_id === selectedScheduleId,
+  );
+
+  const handleSelect = (scheduleId: number | null) => {
+    onScheduleChange(scheduleId);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className='relative w-full'>
+      <button
+        type='button'
+        onClick={() => setIsOpen(!isOpen)}
+        className='w-full px-4 py-3 text-left bg-card border border-border rounded-lg hover:bg-accent transition-colors flex items-center justify-between'
+      >
+        <span
+          className={
+            selectedSchedule ? 'text-foreground' : 'text-muted-foreground'
+          }
+        >
+          {selectedSchedule ? selectedSchedule.schedule_title : placeholder}
+        </span>
+        <ChevronDown
+          className={`w-4 h-4 text-muted-foreground transition-transform ${isOpen ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div className='absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-lg shadow-lg z-[9999] max-h-60 overflow-y-auto'>
+          <button
+            type='button'
+            onClick={() => handleSelect(null)}
+            className={`w-full px-4 py-3 text-left hover:bg-accent transition-colors ${
+              selectedScheduleId === null
+                ? 'bg-primary text-primary-foreground'
+                : ''
+            }`}
+          >
+            선택 안함
+          </button>
+
+          {schedules.map((schedule) => (
+            <button
+              key={schedule.schedule_id}
+              type='button'
+              onClick={() => handleSelect(schedule.schedule_id)}
+              className={`w-full px-4 py-3 text-left hover:bg-accent transition-colors ${
+                selectedScheduleId === schedule.schedule_id
+                  ? 'bg-primary text-primary-foreground'
+                  : ''
+              }`}
+            >
+              {schedule.schedule_title}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* 오버레이 */}
+      {isOpen && (
+        <div
+          className='fixed inset-0 z-[9998]'
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ScheduleDropdown;

--- a/src/pages/(study)/reflection/components/ScoreSlider.tsx
+++ b/src/pages/(study)/reflection/components/ScoreSlider.tsx
@@ -1,0 +1,56 @@
+interface ScoreSliderProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+}
+
+const ScoreSlider = ({
+  label,
+  value,
+  onChange,
+  min = 1,
+  max = 10,
+}: ScoreSliderProps) => {
+  return (
+    <div className='bg-card rounded-lg border border-border p-6'>
+      <div className='flex items-center justify-between mb-4'>
+        <h3 className='text-lg font-semibold text-foreground'>{label}</h3>
+        <span className='text-2xl font-bold text-primary'>
+          {value}/{max}
+        </span>
+      </div>
+
+      <div className='relative'>
+        <input
+          type='range'
+          min={min}
+          max={max}
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className='w-full h-2 bg-secondary rounded-lg appearance-none cursor-pointer slider'
+          style={{
+            background: `linear-gradient(to right, hsl(var(--primary)) 0%, hsl(var(--primary)) ${((value - min) / (max - min)) * 100}%, hsl(var(--secondary)) ${((value - min) / (max - min)) * 100}%, hsl(var(--secondary)) 100%)`,
+          }}
+        />
+
+        {/* 점수 표시 */}
+        <div className='flex justify-between mt-2 text-xs text-muted-foreground'>
+          {Array.from({ length: max - min + 1 }, (_, i) => i + min).map(
+            (num) => (
+              <span
+                key={num}
+                className={value === num ? 'text-primary font-semibold' : ''}
+              >
+                {num}
+              </span>
+            ),
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ScoreSlider;

--- a/src/pages/(study)/reflection/components/index.ts
+++ b/src/pages/(study)/reflection/components/index.ts
@@ -1,0 +1,2 @@
+export { default as ScoreSlider } from './ScoreSlider';
+export { default as ScheduleDropdown } from './ScheduleDropdown';

--- a/src/pages/(study)/reflection/constants/index.ts
+++ b/src/pages/(study)/reflection/constants/index.ts
@@ -1,0 +1,27 @@
+// 회고 페이지 관련 상수
+
+export const REFLECTION_TEXTS = {
+  PAGE_TITLE: '스터디 회고 목록',
+  LIST_TITLE: '회고 목록',
+  DETAIL_TITLE: '회고 작성',
+  WRITE_BUTTON: '회고 작성',
+  MY_REFLECTIONS_ONLY: '내 회고만 보기',
+  OVERALL_SATISFACTION: '전체 만족도',
+  CONTENT_UNDERSTANDING: '내용 이해도',
+  PARTICIPATION: '참여도',
+  LEARNED_CONTENT_QUESTION: '이번 스터디에서 공부한 점과 느낀점은 무엇인가요?',
+  IMPROVEMENT_QUESTION: '다음 스터디에서 개선할 점은 무엇인가요?',
+  SELECT_SCHEDULE_PLACEHOLDER: '연관된 스터디 일정을 선택해주세요..',
+  NO_SCHEDULE_SELECTED: '선택 안함',
+} as const;
+
+export const SCORE_LABELS = {
+  SATISFACTION: '전체 만족도',
+  UNDERSTANDING: '내용 이해도',
+  PARTICIPATION: '참여도',
+} as const;
+
+export const SCORE_RANGE = {
+  MIN: 1,
+  MAX: 10,
+} as const;

--- a/src/pages/(study)/reflection/index.ts
+++ b/src/pages/(study)/reflection/index.ts
@@ -1,4 +1,7 @@
 export { default as ReflectionPage } from './ReflectionPage';
+export { default as ReflectionDetailPage } from './ReflectionDetailPage';
+export { default as ReflectionViewPage } from './ReflectionViewPage';
+export * from './components';
 export * from './types';
 export * from './constants';
 export * from './mock';

--- a/src/pages/(study)/reflection/index.ts
+++ b/src/pages/(study)/reflection/index.ts
@@ -1,0 +1,4 @@
+export { default as ReflectionPage } from './ReflectionPage';
+export * from './types';
+export * from './constants';
+export * from './mock';

--- a/src/pages/(study)/reflection/mock/index.ts
+++ b/src/pages/(study)/reflection/mock/index.ts
@@ -1,0 +1,56 @@
+import type { Reflection, ReflectionListItem, Schedule } from '../types';
+
+// Mock 데이터
+export const mockReflections: ReflectionListItem[] = [
+  {
+    id: 1,
+    title: '첫 번째 회고',
+    author: '김경대',
+    schedule_title: '2025년 9월 20일 3차 회의',
+    updated_at: '2025-09-25T13:00:00',
+  },
+  {
+    id: 2,
+    title: '두 번째 회고',
+    author: '이영희',
+    schedule_title: null,
+    updated_at: '2025-09-24T15:30:00',
+  },
+  {
+    id: 3,
+    title: '세 번째 회고',
+    author: '박민수',
+    schedule_title: '2025년 9월 18일 2차 회의',
+    updated_at: '2025-09-23T10:15:00',
+  },
+];
+
+export const mockSchedules: Schedule[] = [
+  {
+    schedule_id: 1,
+    schedule_title: '2025년 9월 20일 3차 회의',
+  },
+  {
+    schedule_id: 2,
+    schedule_title: '2025년 9월 18일 2차 회의',
+  },
+  {
+    schedule_id: 3,
+    schedule_title: '2025년 9월 15일 1차 회의',
+  },
+];
+
+export const mockReflectionDetail: Reflection = {
+  id: 1,
+  study_id: 10,
+  study_member_id: 5,
+  schedule_id: 1,
+  title: '첫 번째 회고',
+  satisfaction_score: 7,
+  understanding_score: 8,
+  participation_score: 5,
+  learned_content: 'OOP의 기본 개념을 이해하게 되었습니다.',
+  improvement: '다음에는 더 적극적으로 참여하겠습니다.',
+  created_at: '2025-09-25T13:00:00',
+  updated_at: '2025-09-25T13:00:00',
+};

--- a/src/pages/(study)/reflection/mock/index.ts
+++ b/src/pages/(study)/reflection/mock/index.ts
@@ -40,17 +40,56 @@ export const mockSchedules: Schedule[] = [
   },
 ];
 
-export const mockReflectionDetail: Reflection = {
-  id: 1,
-  study_id: 10,
-  study_member_id: 5,
-  schedule_id: 1,
-  title: '첫 번째 회고',
-  satisfaction_score: 7,
-  understanding_score: 8,
-  participation_score: 5,
-  learned_content: 'OOP의 기본 개념을 이해하게 되었습니다.',
-  improvement: '다음에는 더 적극적으로 참여하겠습니다.',
-  created_at: '2025-09-25T13:00:00',
-  updated_at: '2025-09-25T13:00:00',
-};
+export const mockReflectionDetails: Reflection[] = [
+  {
+    id: 1,
+    study_id: 10,
+    study_member_id: 5, // 김경대
+    schedule_id: 1,
+    title: '첫 번째 회고',
+    satisfaction_score: 7,
+    understanding_score: 8,
+    participation_score: 5,
+    learned_content:
+      'OOP의 기본 개념을 이해하게 되었습니다. 클래스와 객체의 관계, 상속과 다형성에 대해 배웠고, 실제 코드에서 어떻게 활용할 수 있는지 알게 되었습니다.',
+    improvement:
+      '다음에는 더 적극적으로 참여하겠습니다. 질문을 더 많이 하고, 팀원들과의 소통을 늘려가겠습니다.',
+    created_at: '2025-09-25T13:00:00',
+    updated_at: '2025-09-25T13:00:00',
+  },
+  {
+    id: 2,
+    study_id: 10,
+    study_member_id: 6, // 이영희
+    schedule_id: null,
+    title: '두 번째 회고',
+    satisfaction_score: 9,
+    understanding_score: 6,
+    participation_score: 8,
+    learned_content:
+      'React의 상태 관리에 대해 깊이 있게 학습했습니다. useState와 useEffect 훅의 사용법을 익혔고, 컴포넌트 간 데이터 전달 방법을 이해했습니다.',
+    improvement:
+      'TypeScript와 함께 사용하는 방법을 더 공부하고 싶습니다. 타입 정의를 더 정확하게 할 수 있도록 연습하겠습니다.',
+    created_at: '2025-09-24T15:30:00',
+    updated_at: '2025-09-24T15:30:00',
+  },
+  {
+    id: 3,
+    study_id: 10,
+    study_member_id: 7, // 박민수
+    schedule_id: 2,
+    title: '세 번째 회고',
+    satisfaction_score: 6,
+    understanding_score: 7,
+    participation_score: 4,
+    learned_content:
+      '데이터베이스 설계와 SQL 쿼리 작성에 대해 배웠습니다. 정규화 과정과 인덱스 최적화 방법을 이해했습니다.',
+    improvement:
+      '실습 시간을 늘려서 더 많은 예제를 다뤄보고 싶습니다. 복잡한 조인 쿼리를 작성하는 연습이 필요합니다.',
+    created_at: '2025-09-23T10:15:00',
+    updated_at: '2025-09-23T10:15:00',
+  },
+];
+
+// 하위 호환성을 위한 기본값 (기존 코드가 사용할 수 있도록)
+export const mockReflectionDetail = mockReflectionDetails[0];

--- a/src/pages/(study)/reflection/types/index.ts
+++ b/src/pages/(study)/reflection/types/index.ts
@@ -1,0 +1,39 @@
+// 회고 관련 타입 정의
+
+export interface Reflection {
+  id: number;
+  study_id: number;
+  study_member_id: number;
+  schedule_id: number | null;
+  title: string;
+  satisfaction_score: number;
+  understanding_score: number;
+  participation_score: number;
+  learned_content: string;
+  improvement: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Schedule {
+  schedule_id: number;
+  schedule_title: string;
+}
+
+export interface ReflectionFormData {
+  schedule_id: number | null;
+  title: string;
+  satisfaction_score: number;
+  understanding_score: number;
+  participation_score: number;
+  learned_content: string;
+  improvement: string;
+}
+
+export interface ReflectionListItem {
+  id: number;
+  title: string;
+  author: string;
+  schedule_title: string | null;
+  updated_at: string;
+}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -111,7 +111,10 @@ const router = createBrowserRouter([
             ],
           },
           { path: ROUTES.STUDY.QUIZ, element: <routes.Example /> },
-          { path: ROUTES.STUDY.RETRO, element: <routes.Example /> },
+          {
+            path: ROUTES.STUDY.REFLECTION,
+            element: <routes.StudyReflection />,
+          },
           {
             path: ROUTES.STUDY.ADMIN.ROOT,
             element: <routes.StudyAdmin />,

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -116,6 +116,18 @@ const router = createBrowserRouter([
             element: <routes.StudyReflection />,
           },
           {
+            path: `${ROUTES.STUDY.REFLECTION}/write`,
+            element: <routes.StudyReflectionDetail />,
+          },
+          {
+            path: `${ROUTES.STUDY.REFLECTION}/:id`,
+            element: <routes.StudyReflectionView />,
+          },
+          {
+            path: `${ROUTES.STUDY.REFLECTION}/:id/edit`,
+            element: <routes.StudyReflectionDetail />,
+          },
+          {
             path: ROUTES.STUDY.ADMIN.ROOT,
             element: <routes.StudyAdmin />,
             children: [

--- a/src/routes/routeConfig.tsx
+++ b/src/routes/routeConfig.tsx
@@ -22,7 +22,11 @@ import {
   ApplicantManagement,
   StudyInfoManagement,
 } from '@/pages/(study)';
-import { ReflectionPage } from '@/pages/(study)/reflection';
+import {
+  ReflectionPage,
+  ReflectionDetailPage,
+  ReflectionViewPage,
+} from '@/pages/(study)/reflection';
 
 // TODO: 팀원과 논의 후 HOC 적용 결정 후 주석 제거
 // import { auth, guest, role } from './routeHelpers';
@@ -56,6 +60,8 @@ export const routes = {
   StudyCreate: StudyCreatePage,
   StudyExplore: StudyExplorePage,
   StudyReflection: ReflectionPage,
+  StudyReflectionDetail: ReflectionDetailPage,
+  StudyReflectionView: ReflectionViewPage,
   NotFound: NotFoundPage,
 
   //  TODO: 팀원과 논의 후 페이지 별 HOC 적용 결정

--- a/src/routes/routeConfig.tsx
+++ b/src/routes/routeConfig.tsx
@@ -22,6 +22,7 @@ import {
   ApplicantManagement,
   StudyInfoManagement,
 } from '@/pages/(study)';
+import { ReflectionPage } from '@/pages/(study)/reflection';
 
 // TODO: 팀원과 논의 후 HOC 적용 결정 후 주석 제거
 // import { auth, guest, role } from './routeHelpers';
@@ -54,6 +55,7 @@ export const routes = {
   StudyAdminStudyInfo: StudyInfoManagement,
   StudyCreate: StudyCreatePage,
   StudyExplore: StudyExplorePage,
+  StudyReflection: ReflectionPage,
   NotFound: NotFoundPage,
 
   //  TODO: 팀원과 논의 후 페이지 별 HOC 적용 결정


### PR DESCRIPTION
## ✨ 요약

> 스터디 회고 기능의 전체 페이지를 구현하고 권한 기반 시스템을 적용하여 작성자만 수정할 수 있도록 구현했습니다.

## 🔗 작업 내용

- 회고 목록 페이지 UI 구현 및 디자인 시스템 적용
- 회고 작성/수정 페이지 구현 (폼, 점수 슬라이더, 드롭다운)
- 회고 읽기 전용 상세보기 페이지 구현
- 권한 기반 시스템 구현 (작성자만 수정 가능)
- 라우팅 구조 개선 (읽기/쓰기 페이지 분리)
- 커스텀 컴포넌트 구현 (ScoreSlider, ScheduleDropdown)

## 💻 상세 구현 내용

###  **페이지 구조**
- **`/study/reflection`** - 회고 목록 페이지
- **`/study/reflection/write`** - 새 회고 작성
- **`/study/reflection/:id`** - 회고 상세보기 (읽기 전용)
- **`/study/reflection/:id/edit`** - 회고 수정 (작성자만)

###  **UI/UX 개선**
- 스터디 진척도와 일관된 디자인 패턴 적용
- 평가 섹션을 가로 배치로 변경 (피그마 디자인 반영)
- 드롭다운 z-index 문제 해결로 뒤 내용 비침 현상 해결
- 헤더 아이콘 제거 및 중복 버튼 정리

###  **권한 관리 시스템**
- 현재 사용자와 작성자 ID 비교로 권한 체크
- 작성자에게만 수정 버튼 표시
- 라우팅 레벨에서 읽기/쓰기 페이지 완전 분리

###  **커스텀 컴포넌트**
- **`ScoreSlider`**: 1-10점 점수 입력용 슬라이더
- **`ScheduleDropdown`**: 스케줄 선택 드롭다운 (z-index 문제 해결)

###  **데이터 구조**
- 각 회고 ID별 고유한 상세 데이터 생성
- Mock 데이터 확장으로 실제 사용 시나리오 구현
- 작성자별 다른 점수 및 내용 표시

## 🔗 참고 사항

- 현재는 Mock 데이터를 사용하고 있으며, 실제 API 연결 시 인증 상태에서 사용자 ID를 가져와야 합니다
- ReflectionViewPage와 ReflectionDetailPage에서 currentUserId를 실제 인증 시스템과 연결해야 합니다
- 드롭다운 컴포넌트는 z-index를 9999로 설정하여 다른 요소들 위에 표시되도록 구현했습니다

## 📸 스크린샷 (Screenshots)

- 회고 목록
<img width="1470" height="793" alt="image" src="https://github.com/user-attachments/assets/c83b4e7b-1d65-4608-be17-99219d3b4aca" />

- 회고 작성
<img width="1470" height="798" alt="image" src="https://github.com/user-attachments/assets/63f13aa8-58c6-4827-815e-7e6f69a00cf6" />

- 회고 수정
<img width="1470" height="798" alt="image" src="https://github.com/user-attachments/assets/14cf112d-252d-4a0f-a0f4-ed663a36cf70" />

## 🔗 관련 이슈

- Close #59 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
