### PR TITLE
feat(schedule): 일정 관리 페이지 일정 참석, 불참 api 연결

### DIFF
--- a/src/api/constants/attendanceEndpoints.ts
+++ b/src/api/constants/attendanceEndpoints.ts
@@ -2,4 +2,9 @@
 export const ATTENDANCE_ENDPOINTS = {
   // 전체 참여 현황 조회
   STUDY: (study_id: number) => `/api/studies/${study_id}/attendances`,
+
+  ATTENDANCES_ME: (schedule_id: number) =>
+    `/api/schedules/${schedule_id}/attendances/me`,
+
+  ME: (schedule_id: number) => `/api/schedules/${schedule_id}/me`,
 } as const;

--- a/src/constants/queryKeys/attendance.ts
+++ b/src/constants/queryKeys/attendance.ts
@@ -3,4 +3,5 @@
  */
 export const attendanceKeys = {
   study: (study_id: number) => ['attendance-study', study_id] as const,
+  me: (schedule_id: number) => ['attendance-me', schedule_id] as const,
 } as const;

--- a/src/pages/(study)/schedule/Manage/components/ScheduleManageCard.tsx
+++ b/src/pages/(study)/schedule/Manage/components/ScheduleManageCard.tsx
@@ -19,7 +19,7 @@ type ScheduleManageCardProps = {
 const ScheduleManageCard = ({ event }: ScheduleManageCardProps) => {
   const { study_id } = useParams<{ study_id: string }>();
   const user = useAuthStore((s) => s.user);
-  const { data: attendanceData } = useAttendanceMeQuery({
+  const { data: attendanceData, isPending } = useAttendanceMeQuery({
     schedule_id: event.id,
   });
   const { mutate: attendanceMeMutate } = useAttendanceMeMutation({
@@ -64,6 +64,7 @@ const ScheduleManageCard = ({ event }: ScheduleManageCardProps) => {
           type='button'
           className={`text-white px-4 py-2 rounded-lg cursor-pointer transition ${attendanceData.status ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700'}`}
           onClick={() => handleAttendanceChange(!attendanceData.status)}
+          disabled={isPending}
         >
           {attendanceData.status ? '참여' : '불참'}
         </button>

--- a/src/pages/(study)/schedule/Manage/components/ScheduleManageCard.tsx
+++ b/src/pages/(study)/schedule/Manage/components/ScheduleManageCard.tsx
@@ -1,9 +1,10 @@
 import type { Dayjs } from 'dayjs';
-import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useScheduleDelete } from '../hooks/useScheduleDelete';
 import { X } from 'lucide-react';
 import { useAuthStore } from '@/stores';
+import { useAttendanceMeQuery } from '../hooks/useAttendanceMeQuery';
+import { useAttendanceMeMutation } from '../hooks/useAttendanceMeMutation';
 
 type ScheduleManageCardProps = {
   event: {
@@ -18,10 +19,22 @@ type ScheduleManageCardProps = {
 const ScheduleManageCard = ({ event }: ScheduleManageCardProps) => {
   const { study_id } = useParams<{ study_id: string }>();
   const user = useAuthStore((s) => s.user);
-  const [attend, setAttend] = useState(false);
+  const { data: attendanceData } = useAttendanceMeQuery({
+    schedule_id: event.id,
+  });
+  const { mutate: attendanceMeMutate } = useAttendanceMeMutation({
+    study_id: Number(study_id),
+  });
   const { mutate: deleteSchedule } = useScheduleDelete({
     study_id: Number(study_id),
   });
+
+  const handleAttendanceChange = (status: boolean) => {
+    attendanceMeMutate({
+      schedule_id: event.id,
+      status,
+    });
+  };
 
   return (
     <div className='flex flex-col bg-blue-100 rounded-xl p-4'>
@@ -49,10 +62,10 @@ const ScheduleManageCard = ({ event }: ScheduleManageCardProps) => {
       <div className='flex justify-end mt-2'>
         <button
           type='button'
-          className={`text-white px-4 py-2 rounded-lg cursor-pointer transition ${attend ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700'}`}
-          onClick={() => setAttend(!attend)}
+          className={`text-white px-4 py-2 rounded-lg cursor-pointer transition ${attendanceData.status ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700'}`}
+          onClick={() => handleAttendanceChange(!attendanceData.status)}
         >
-          {attend ? '참여' : '불참'}
+          {attendanceData.status ? '참여' : '불참'}
         </button>
       </div>
     </div>

--- a/src/pages/(study)/schedule/Manage/hooks/useAttendanceMeMutation.ts
+++ b/src/pages/(study)/schedule/Manage/hooks/useAttendanceMeMutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { attendanceKeys } from '@/constants/queryKeys';
+import { attendanceMeService, type AttendanceMeRequest } from '../services';
+
+export const useAttendanceMeMutation = ({ study_id }: { study_id: number }) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: AttendanceMeRequest) => attendanceMeService(params),
+
+    onSuccess: (_, variables) => {
+      // 출석 정보 업데이트 성공 시 해당 스터디의 출석 정보 쿼리 무효화
+      queryClient.invalidateQueries({
+        queryKey: attendanceKeys.me(variables.schedule_id),
+        exact: true,
+      });
+      queryClient.invalidateQueries({
+        queryKey: attendanceKeys.study(study_id),
+      });
+    },
+
+    onError: (error) => {
+      console.error('스터디 출석 정보 업데이트 실패:', error);
+      alert('출석 정보 업데이트에 실패했습니다. 다시 시도해주세요.');
+    },
+  });
+};

--- a/src/pages/(study)/schedule/Manage/hooks/useAttendanceMeQuery.ts
+++ b/src/pages/(study)/schedule/Manage/hooks/useAttendanceMeQuery.ts
@@ -1,0 +1,16 @@
+import { attendanceKeys } from '@/constants/queryKeys';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { attendanceGetMeService } from '../services';
+
+type AttendanceMeQueryParams = {
+  schedule_id: number;
+};
+
+export const useAttendanceMeQuery = ({
+  schedule_id,
+}: AttendanceMeQueryParams) => {
+  return useSuspenseQuery({
+    queryKey: attendanceKeys.me(schedule_id),
+    queryFn: () => attendanceGetMeService({ schedule_id }),
+  });
+};

--- a/src/pages/(study)/schedule/Manage/hooks/useScheduleAddMutation.ts
+++ b/src/pages/(study)/schedule/Manage/hooks/useScheduleAddMutation.ts
@@ -3,7 +3,7 @@ import {
   scheduleAddService,
   type ScheduleAddRequest,
 } from '../services/scheduleAddService';
-import { scheduleKeys } from '@/constants/queryKeys';
+import { attendanceKeys, scheduleKeys } from '@/constants/queryKeys';
 
 export const useScheduleAddMutation = () => {
   const queryClient = useQueryClient();
@@ -16,6 +16,9 @@ export const useScheduleAddMutation = () => {
       queryClient.invalidateQueries({
         queryKey: scheduleKeys.study(variables.study_id),
         exact: true,
+      });
+      queryClient.invalidateQueries({
+        queryKey: attendanceKeys.study(variables.study_id),
       });
     },
 

--- a/src/pages/(study)/schedule/Manage/services/attendanceGetMeService.ts
+++ b/src/pages/(study)/schedule/Manage/services/attendanceGetMeService.ts
@@ -1,0 +1,27 @@
+import apiClient from '@/api';
+import { ATTENDANCE_ENDPOINTS } from '@/api/constants';
+
+type AttendanceGetMeResponse = {
+  status: boolean;
+};
+
+type AttendanceGetMeRequest = {
+  schedule_id: number;
+};
+
+/**
+ * 스터디 출석 서비스 (axios thin)
+ */
+export const attendanceGetMeService = async ({
+  schedule_id,
+}: AttendanceGetMeRequest): Promise<AttendanceGetMeResponse> => {
+  const { data } = await apiClient.get<AttendanceGetMeResponse>(
+    ATTENDANCE_ENDPOINTS.ME(schedule_id),
+  );
+
+  if (!data) {
+    throw new Error('스터디 출석 정보 조회에 실패했습니다.');
+  }
+
+  return data;
+};

--- a/src/pages/(study)/schedule/Manage/services/attendanceMeService.ts
+++ b/src/pages/(study)/schedule/Manage/services/attendanceMeService.ts
@@ -1,0 +1,29 @@
+import apiClient from '@/api';
+import { ATTENDANCE_ENDPOINTS } from '@/api/constants';
+
+export type AttendanceMeRequest = {
+  schedule_id: number;
+  status: boolean;
+};
+
+/**
+ * 스터디 출석 추가 서비스 (axios thin)
+ */
+export const attendanceMeService = async ({
+  schedule_id,
+  status,
+}: AttendanceMeRequest) => {
+  const { data } = await apiClient.patch<AttendanceMeRequest>(
+    ATTENDANCE_ENDPOINTS.ATTENDANCES_ME(schedule_id),
+    { status },
+  );
+
+  // 백엔드가 200 또는 204로 빈 바디를 반환할 수 있음.
+  // 이 경우에도 요청은 성공이므로 예외를 던지지 않고 응답 데이터를 그대로 반환하거나
+  // 빈 객체를 반환하여 호출 측이 정상 처리하도록 허용한다.
+  if (data === null || data === undefined) {
+    return {} as AttendanceMeRequest;
+  }
+
+  return data;
+};

--- a/src/pages/(study)/schedule/Manage/services/index.ts
+++ b/src/pages/(study)/schedule/Manage/services/index.ts
@@ -1,3 +1,5 @@
 export * from './scheduleStudyService';
 export * from './attendanceStudyService';
 export * from './scheduleAddService';
+export * from './attendanceGetMeService';
+export * from './attendanceMeService';


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

일정 관리 페이지의 일정 참석, 불참 여부를 api 연결하였습니다. 

## 🔗 작업 내용

- [x] 참석, 불참 여부 api 연결

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

일정의 참석, 불참을 결정할 수 있는 api를 연결하였습니다. 
일정을 추가하였을 때 스터디 참여 현황을 다시 받아오도록 하였습니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)

<img width="1431" height="808" alt="스크린샷 2025-11-05 오후 3 48 00" src="https://github.com/user-attachments/assets/daaf8225-4f54-45b5-a688-6ca614fa2296" />

## 🔗 관련 이슈

- Close #83 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
