### PR TITLE
refactor : 웹소켓 연결 안정화 및 기타 UI 사항 개선

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -5,6 +5,7 @@ import { useChatMessages, useChatConnection, useSendMessage } from './hooks';
 import { chatService } from './chatService';
 import { getCurrentKoreanTime } from './utils/timeUtils';
 import type { ChatMessage } from './types';
+import { useAuthStore } from '@/stores/auth';
 
 interface ChatWidgetProps {
   studyId: string;
@@ -30,6 +31,7 @@ export function ChatWidget({ studyId }: ChatWidgetProps) {
   } = useChatMessages(studyId);
   const { connectionState } = useChatConnection();
   const sendMessageMutation = useSendMessage();
+  const { accessToken } = useAuthStore();
 
   // WebSocket을 통한 실시간 메시지 수신 핸들러
   const handleNewMessage = useCallback(
@@ -54,7 +56,9 @@ export function ChatWidget({ studyId }: ChatWidgetProps) {
       // 연결이 되어있으면 바로 구독
       if (chatService.isConnected) {
         chatService.subscribeToChat(studyId, handleNewMessage);
-        loadChatHistory();
+        if (accessToken) {
+          loadChatHistory();
+        }
       } else {
         // 연결 상태 변화 감지하여 연결 완료 시 구독 시작
         const targetStudyId = studyId; // 클로저에서 studyId 고정
@@ -63,7 +67,9 @@ export function ChatWidget({ studyId }: ChatWidgetProps) {
             // 연결 완료 시 해당 스터디에 구독
             if (state.isConnected) {
               chatService.subscribeToChat(targetStudyId, handleNewMessage);
-              loadChatHistory();
+              if (accessToken) {
+                loadChatHistory();
+              }
             }
           },
         );
@@ -83,7 +89,7 @@ export function ChatWidget({ studyId }: ChatWidgetProps) {
       // 현재 스터디의 채팅 구독 해제
       chatService.unsubscribeFromChat(studyId);
     };
-  }, [studyId, handleNewMessage, loadChatHistory]);
+  }, [studyId, handleNewMessage, loadChatHistory, accessToken]);
 
   // 위젯 열림 시 채팅 기록만 로드 (구독은 이미 되어있음)
   const initializeChat = useCallback(async () => {
@@ -91,10 +97,10 @@ export function ChatWidget({ studyId }: ChatWidgetProps) {
   }, [loadChatHistory]);
 
   useEffect(() => {
-    if (isOpen && studyId) {
+    if (isOpen && studyId && accessToken) {
       initializeChat();
     }
-  }, [isOpen, studyId, initializeChat]);
+  }, [isOpen, studyId, initializeChat, accessToken]);
 
   // 텍스트 메시지 전송(엔터/버튼) 및 전송 중/실패 처리
   // 낙관적 업데이트로 즉시 UI에 표시하고 서버로 전송

--- a/src/components/chat/chatService.ts
+++ b/src/components/chat/chatService.ts
@@ -67,7 +67,9 @@ export class ChatService {
   }
 
   private createClient() {
-    const wsUrl = `${CHAT_SERVICE_CONFIG.API_BASE_URL}${CHAT_SERVICE_CONFIG.WEBSOCKET_PATH}`;
+    const base = CHAT_SERVICE_CONFIG.API_BASE_URL.replace(/\/+$/, '');
+    const path = `/${String(CHAT_SERVICE_CONFIG.WEBSOCKET_PATH).replace(/^\/+/, '')}`;
+    const wsUrl = `${base}${path}`;
     const socket = new SockJS(wsUrl);
 
     this.client = new Client({
@@ -238,6 +240,8 @@ export class ChatService {
     this.messageSubscribers.clear();
     this.connectionStateListeners.clear();
     this.reconnectAttempts = 0;
+    // 다음 연결 시 새로운 SockJS/STOMP 클라이언트를 생성하도록 초기화
+    this.client = null;
   }
 }
 

--- a/src/components/user/UserProfileSection.tsx
+++ b/src/components/user/UserProfileSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { User, Settings, LogOut } from 'lucide-react';
+import { LogOut } from 'lucide-react';
 import { useLogoutMutation } from '@/hooks';
 import { useAuthUserSuspense } from '@/hooks/useAuthUserSuspense';
 import { ROUTES } from '@/constants';
@@ -39,32 +39,8 @@ const UserProfileSection: React.FC<UserProfileSectionProps> = ({
     onMobileMenuClose?.();
   };
 
-  // 프로필 관리 핸들러
-  const handleProfileManage = () => {
-    // TODO: 마이페이지로 이동 라우팅 연결
-    setIsDropdownOpen(false);
-    onMobileMenuClose?.();
-  };
-
-  // 설정 이동 핸들러
-  const handleOpenSettings = () => {
-    // TODO: 설정 페이지로 이동 라우팅 연결
-    setIsDropdownOpen(false);
-    onMobileMenuClose?.();
-  };
-
-  // 드롭다운 메뉴 아이템 (마이페이지 / 설정 / 로그아웃)
+  // 드롭다운 메뉴 아이템 (로그아웃만)
   const menuItems = [
-    {
-      icon: <User className='w-4 h-4' />,
-      label: '마이페이지',
-      onClick: handleProfileManage,
-    },
-    {
-      icon: <Settings className='w-4 h-4' />,
-      label: '설정',
-      onClick: handleOpenSettings,
-    },
     {
       icon: <LogOut className='w-4 h-4' />,
       label: '로그아웃',

--- a/src/hooks/auth/mutations/useLogoutMutation.ts
+++ b/src/hooks/auth/mutations/useLogoutMutation.ts
@@ -5,6 +5,7 @@ import apiClient from '@/api';
 import { AUTH_ENDPOINTS } from '@/api/constants';
 import { useAuthStore } from '@/stores/auth';
 import { ROUTES } from '@/constants';
+import { queryClient } from '@/libs/queryClient';
 
 /**
  * 로그아웃 뮤테이션 훅
@@ -18,6 +19,8 @@ export const useLogoutMutation = () => {
   return useMutation({
     // 즉시 UX 응답: 낙관적 내비게이션 + 스토어 리셋
     onMutate: () => {
+      // React Query 캐시를 먼저 정리하여 이전 계정 데이터 잔존 방지
+      queryClient.clear();
       reset();
       // 초기화 완료 상태를 유지하여 게스트 UI가 즉시 렌더링되도록 보장
       setIsInitialized(true);

--- a/src/hooks/auth/mutations/useLogoutMutation.ts
+++ b/src/hooks/auth/mutations/useLogoutMutation.ts
@@ -6,6 +6,7 @@ import { AUTH_ENDPOINTS } from '@/api/constants';
 import { useAuthStore } from '@/stores/auth';
 import { ROUTES } from '@/constants';
 import { queryClient } from '@/libs/queryClient';
+import { chatService } from '@/components/chat/chatService';
 
 /**
  * 로그아웃 뮤테이션 훅
@@ -21,6 +22,16 @@ export const useLogoutMutation = () => {
     onMutate: () => {
       // React Query 캐시를 먼저 정리하여 이전 계정 데이터 잔존 방지
       queryClient.clear();
+      // 실시간 연결 해제하여 이전 토큰/세션으로 송신되는 문제 방지
+      try {
+        chatService.disconnect();
+      } catch (error) {
+        if (import.meta.env.DEV) {
+          // 로그아웃 시점에 이미 해제된 상태일 수 있으므로 경고만 남김
+          // eslint-disable-next-line no-console
+          console.warn('[logout] chatService.disconnect() 실패', error);
+        }
+      }
       reset();
       // 초기화 완료 상태를 유지하여 게스트 UI가 즉시 렌더링되도록 보장
       setIsInitialized(true);

--- a/src/libs/queryClient.ts
+++ b/src/libs/queryClient.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from '@tanstack/react-query';
+
+// 전역 단일 QueryClient 인스턴스
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+    },
+  },
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,29 +1,16 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ToastContainer } from 'react-toastify';
 
 import '@/styles/index.css';
 import 'react-toastify/dist/ReactToastify.css';
 import App from './App';
+import { queryClient } from '@/libs/queryClient';
 import { AuthInitializer as AuthUtils } from '@/utils/auth';
 
-// React Query 클라이언트 생성 - 필수 최적화 설정
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      // 캐시 시간: 5분 (API 중복 요청 방지)
-      staleTime: 5 * 60 * 1000,
-      // 백그라운드에서 데이터 갱신 시간: 10분
-      gcTime: 10 * 60 * 1000,
-      // 윈도우 포커스 시 자동 리페치 비활성화 (auth 폼에서는 불필요)
-      refetchOnWindowFocus: false,
-      // 네트워크 재연결 시 자동 리페치 활성화
-      refetchOnReconnect: true,
-    },
-  },
-});
+// QueryClient는 전역 단일 인스턴스를 사용합니다 (src/libs/queryClient)
 
 // 전역 인증 초기화: 렌더를 막지 않고 비동기로 시작
 void AuthUtils.init();

--- a/src/pages/(auth)/login/hooks/mutations/useLoginMutation.ts
+++ b/src/pages/(auth)/login/hooks/mutations/useLoginMutation.ts
@@ -5,6 +5,7 @@ import { ROUTES } from '@/constants';
 import { useAuthStore } from '@/stores/auth';
 import { loadAndCacheAuthUser } from '@/utils/authUserLoader';
 import { loginService } from '../../services';
+import { queryClient } from '@/libs/queryClient';
 
 /**
  * 로그인 뮤테이션 훅
@@ -19,6 +20,8 @@ export const useLoginMutation = () => {
   return useMutation({
     mutationFn: (payload: LoginPayload) => loginService(payload),
     onSuccess: async (result) => {
+      // 로그인 직전 잔존 캐시를 정리해 사용자 전환 시 데이터 섞임 방지
+      queryClient.clear();
       // 액세스 토큰을 메모리에 저장 (리프레시 토큰은 HttpOnly 쿠키로 자동 관리)
       if ((result as { accessToken?: string })?.accessToken) {
         const accessToken = (result as { accessToken: string }).accessToken;

--- a/src/pages/(auth)/signup/components/Step1Form.tsx
+++ b/src/pages/(auth)/signup/components/Step1Form.tsx
@@ -105,11 +105,6 @@ export const Step1Form: React.FC<Step1FormProps> = ({
           error={errors.email?.message}
           {...register('email')}
         />
-        {isCodeVerified && (
-          <span className='inline-flex items-center gap-1 px-2 py-1 rounded-md bg-green-100 text-green-700 text-xs'>
-            <ShieldCheck className='w-3 h-3' /> 인증 완료
-          </span>
-        )}
         <button
           type='button'
           onClick={handleSendCode}

--- a/src/pages/(study)/components/layout/StudyLayout.tsx
+++ b/src/pages/(study)/components/layout/StudyLayout.tsx
@@ -6,6 +6,7 @@ import { ChatWidget } from '@/components/chat';
 import { useChatConnection } from '@/components/chat/hooks';
 import { useAuthStore } from '@/stores/auth';
 import { ROUTE_PARAMS } from '@/constants';
+import { useCurrentStudy } from '@/hooks/study/useCurrentStudy';
 
 /**
  * (study) 도메인 전용 레이아웃
@@ -18,6 +19,14 @@ function StudyLayout() {
   const { [ROUTE_PARAMS.studyId]: studyId } = useParams();
   const { connectWebSocket } = useChatConnection();
   const { accessToken, isInitialized } = useAuthStore();
+
+  // 스터디 진입 시 현재 스터디 정보 동기화 (역할/타이틀)
+  const numericStudyId = studyId ? Number(studyId) : undefined;
+  useCurrentStudy(
+    typeof numericStudyId === 'number' && !isNaN(numericStudyId)
+      ? numericStudyId
+      : undefined,
+  );
 
   // 스터디 페이지 진입 시 웹소켓 연결 시작 (구독은 ChatWidget에서 관리)
   // 인증 토큰이 준비된 후에만 연결 시도

--- a/src/pages/(study)/components/layout/StudyLayout.tsx
+++ b/src/pages/(study)/components/layout/StudyLayout.tsx
@@ -18,7 +18,7 @@ function StudyLayout() {
   const [open, setOpen] = useState(false);
   const { [ROUTE_PARAMS.studyId]: studyId } = useParams();
   const { connectWebSocket } = useChatConnection();
-  const { accessToken, isInitialized } = useAuthStore();
+  const { accessToken, isInitialized, user } = useAuthStore();
 
   // 스터디 진입 시 현재 스터디 정보 동기화 (역할/타이틀)
   const numericStudyId = studyId ? Number(studyId) : undefined;
@@ -38,6 +38,15 @@ function StudyLayout() {
       return;
     }
 
+    // 현재 스터디 접근 권한(멤버십)이 확인된 뒤에만 연결
+    const currentStudyIdFromStore = user.currentStudy?.study_id;
+    if (
+      !currentStudyIdFromStore ||
+      String(currentStudyIdFromStore) !== studyId
+    ) {
+      return;
+    }
+
     const initializeConnection = async () => {
       try {
         await connectWebSocket();
@@ -49,7 +58,13 @@ function StudyLayout() {
     initializeConnection();
 
     // 연결은 전역적으로 유지하고, 구독 해제는 ChatWidget에서 관리
-  }, [studyId, connectWebSocket, accessToken, isInitialized]);
+  }, [
+    studyId,
+    connectWebSocket,
+    accessToken,
+    isInitialized,
+    user.currentStudy?.study_id,
+  ]);
 
   return (
     <div className='flex h-screen bg-background overflow-hidden'>

--- a/src/pages/(study)/components/layout/sidebar/SidebarNav.tsx
+++ b/src/pages/(study)/components/layout/sidebar/SidebarNav.tsx
@@ -1,15 +1,24 @@
 import { NavLink } from 'react-router-dom';
 import { STUDY_NAV_ITEMS } from '@/pages/(study)/constants';
+import { ROUTES } from '@/constants';
+import { useAuthStatus } from '@/hooks/auth/useAuthStatus';
 
 /**
  * 사이드바 네비게이션 컴포넌트
  * 스터디 관련 메뉴 항목들을 표시하고 활성 상태를 관리합니다.
  */
 function SidebarNav() {
+  const { isStudyLeader } = useAuthStatus();
+
+  // 리더가 아닌 경우 관리자 메뉴 항목 제외
+  const navItems = isStudyLeader
+    ? STUDY_NAV_ITEMS
+    : STUDY_NAV_ITEMS.filter((item) => item.to !== ROUTES.STUDY.ADMIN.ROOT);
+
   return (
     <nav className='p-4'>
       <ul className='space-y-1.5'>
-        {STUDY_NAV_ITEMS.map((item) => {
+        {navItems.map((item) => {
           return (
             <li key={item.to}>
               <NavLink


### PR DESCRIPTION
## ✨ 요약

> 웹소켓 연결 안정화 및 인증 전환 시 잔존 데이터/연결 문제를 해결했습니다. 또한 프로필 드롭다운을 단일 로그아웃 항목으로 단순화하고, 스터디 역할 동기화를 개선하여 관리자 메뉴 노출과 연결 타이밍을 바로잡았습니다.

## 🔗 작업 내용

- refactor(main): QueryClient 인스턴스 중앙화 및 인증 훅 정리
- fix(chat): 웹소켓 URL 조합 보정, 토큰 준비 후에만 채팅 기록 로드, 로그아웃 시 실시간 연결 해제
- fix(ui/profile): 프로필 드롭다운에서 마이페이지/설정 제거, 로그아웃만 유지
- refactor(signup): 중복되고 깨지는 이메일 인증 완료 표시 제거

## 💻 상세 구현 내용

- QueryClient 중앙화
  - `src/libs/queryClient.ts`에 단일 인스턴스 생성, `src/main.tsx`에서 주입
  - 로그인/로그아웃 시 `queryClient.clear()`로 사용자 전환 시 잔존 캐시 제거
- 인증 전환 처리
  - `useLoginMutation`: 성공 시 캐시 초기화 후 토큰/프로필 로드
  - `useLogoutMutation`: 캐시 초기화 + `chatService.disconnect()`로 실시간 연결 해제
- 스터디 역할/연결 타이밍
  - `StudyLayout`: `useCurrentStudy(studyId)`로 진입 시 현재 스터디 동기화
  - 웹소켓 연결 조건 강화: 토큰 존재 및 현재 스터디 멤버십 확인 후에만 연결
  - 의존성에 `user.currentStudy?.study_id` 추가해 새로고침 없이도 재연결 트리거
- 채팅(웹소켓/REST) 안정화
  - `chatService`: 웹소켓 URL 조합 시 이중 슬래시 제거, disconnect 후 `client = null`로 초기화
  - `ChatWidget`: 연결/열림 시 `accessToken`이 있을 때만 `loadChatHistory()` 호출
- UI 단순화
  - `UserProfileSection`: 드롭다운 메뉴에서 마이페이지/설정 제거, 로그아웃만 유지
- 중복되고 깨지는 이메일 인증 완료 표시 제거

## 🔗 참고 사항

- 배포 환경에서 `/ws` CORS는 서버/프록시에서 허용되어야 합니다(Origin, Credentials 등).
- REST와 WS 베이스가 분리되지 않은 전제에서, URL 정규화만 적용했습니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #이슈번호

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
